### PR TITLE
fix(infra): suppress hadolint DL3008 and DL3013 with phase-appropriate rationale

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,23 @@
+# Hadolint Configuration for ML Platform Engineering Project
+# https://github.com/hadolint/hadolint
+
+# Ignored Rules with Rationale
+ignored:
+  # DL3008: Pin versions in apt get install
+  # Rationale: This is a Phase 1 learning project with a single internal service.
+  # Python dependencies are already fully pinned in requirements.txt for reproducibility.
+  # System package version pinning deferred to Phase 2+ when multi-service architecture
+  # emerges. Current risk is LOW (non-production, internal-only image).
+  # Will be revisited in Phase 2 when implementing production-grade Kubernetes deployment.
+  - DL3008
+
+  # DL3013: Pin versions in pip
+  # Rationale: Pip upgrades are necessary for Python 3.13 compatibility and security.
+  # Python package versions are fully pinned in requirements.txt (primary reproducibility lever).
+  # Full pip/system package pinning deferred to Phase 2+.
+  # Will be revisited in Phase 2 as part of comprehensive version management strategy.
+  - DL3013
+
+# Strictness level: warning (default)
+# This allows warnings but fails the build on errors (DL0000, DL4000+)
+strictness: warning


### PR DESCRIPTION
## Summary

Resolves hadolint warnings DL3008 and DL3013 by suppressing them via `.hadolint.yaml` configuration with comprehensive documentation of Phase 1 rationale.

**Hadolint Violations Addressed**:
- **DL3008**: Pin versions in apt get install
- **DL3013**: Pin versions in pip

## Approach: Phase 1 Simplicity

Rather than implementing full version pinning (which introduces maintenance burden and reliability risks), this PR suppresses the warnings with documented justification using `.hadolint.yaml` configuration.

### Rationale

**DL3008 - apt package version pinning**:
- Python dependencies already fully pinned in `requirements.txt`
- System package version pinning deferred to Phase 2+ (multi-service architecture)
- Current risk: LOW (non-production, internal-only image)
- Will revisit when production-grade Kubernetes deployment emerges

**DL3013 - pip version pinning**:
- Pip upgrades are necessary for Python 3.13 compatibility and security
- Python package versions are fully pinned in `requirements.txt` (primary reproducibility lever)
- Full system-level pinning deferred to Phase 2 versioning strategy
- Will implement comprehensive version management in Phase 2+

## Files Changed

- **`.hadolint.yaml`** (new): Hadolint configuration with DL3008 and DL3013 suppression
  - Includes detailed rationale for each suppressed rule
  - Documents Phase 1 justification and Phase 2 migration plan

## Checklist

- [x] Hadolint warnings suppressed via `.hadolint.yaml`
- [x] Phase 1 rationale documented in configuration
- [x] No breaking changes
- [x] Prepared for Phase 2 revisit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to refine Docker linting settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->