### PR TITLE
ci(pre-commit): document rationale for Semgrep test exclusion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -111,7 +111,10 @@ repos:
           - --timeout=60           # Prevent hanging on complex files
           - --verbose              # Show which rules are running
         files: \.py$               # Only scan Python files
-        exclude: ^tests/           # Skip tests (covered by comprehensive CI scan)
+        # Exclude tests for pre-commit speed optimization
+        # Tests are scanned comprehensively in CI (see .github/workflows/ci.yml)
+        # Rationale: Developer feedback speed > comprehensive pre-commit coverage
+        exclude: ^tests/
 
   # Markdown linting
   - repo: https://github.com/igorshubovych/markdownlint-cli


### PR DESCRIPTION
## Summary

Added explanatory comments to the Semgrep pre-commit hook configuration documenting why the `tests/` directory is excluded from pre-commit scanning. This addresses feedback from code review about making the intentional design decision explicit.

## Changes

- **Updated** `.pre-commit-config.yaml` - Added three comment lines explaining:
  - Tests are excluded for pre-commit speed optimization
  - Tests receive comprehensive scanning in CI pipeline
  - Rationale: Developer feedback speed prioritized over pre-commit coverage

## Test Plan

- [x] Pre-commit hooks pass on modified file
- [x] YAML syntax validated (yamllint passed)
- [x] No functional changes to pre-commit behavior
- [x] Documentation accurately reflects current implementation

## Related Issues

Closes #52

## Notes

This is a documentation-only change with no impact on functionality. The `exclude: ^tests/` directive remains unchanged - only explanatory comments were added to make the design decision explicit for future maintainers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration file with clarifying comments. No functional changes to behavior or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->