### PR TITLE
fix(terraform): use globally unique S3 bucket name

### DIFF
--- a/.github/workflows/eks-deploy.yml
+++ b/.github/workflows/eks-deploy.yml
@@ -418,7 +418,7 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Create S3 bucket for Terraform state
         run: |
-          BUCKET="ml-platform-terraform-state"
+          BUCKET="ml-platform-terraform-state-984479408136"
           REGION="us-west-2"
 
           echo "🪣 Creating S3 bucket: ${BUCKET}"
@@ -645,7 +645,7 @@ jobs:
         run: |
           echo "🔍 Validating Terraform backend resources..."
 
-          BUCKET="ml-platform-terraform-state"
+          BUCKET="ml-platform-terraform-state-984479408136"
           TABLE="ml-platform-terraform-locks"
           REGION="us-west-2"
 

--- a/terraform/environments/dev/backend.tf
+++ b/terraform/environments/dev/backend.tf
@@ -4,7 +4,7 @@
 
 terraform {
   backend "s3" {
-    bucket         = "ml-platform-terraform-state"
+    bucket         = "ml-platform-terraform-state-984479408136"
     key            = "dev/terraform.tfstate"
     region         = "us-west-2"
     encrypt        = true


### PR DESCRIPTION
## Summary
Fixes bootstrap workflow failure by using globally unique S3 bucket name.

## Problem
- Bootstrap workflow failed with BucketAlreadyExists error
- Bucket name 'ml-platform-terraform-state' is already taken globally

## Solution  
- Append AWS account ID (984479408136) to make bucket name unique
- Updated: backend.tf, eks-deploy.yml (2 locations)

## Testing
- Will trigger bootstrap workflow after merge

Blocks: #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend infrastructure storage configuration references in deployment automation and infrastructure-as-code components to use updated resource identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->