### PR TITLE
hotfix(terraform): remove cross-variable validations from networking module

### DIFF
--- a/terraform/modules/networking/variables.tf
+++ b/terraform/modules/networking/variables.tf
@@ -35,10 +35,12 @@ variable "private_subnet_cidrs" {
   description = "List of CIDR blocks for private subnets"
   type        = list(string)
 
+  # Note: Terraform variable validations can only reference the variable being validated (self).
+  # Cross-variable validation (e.g., subnet count == AZ count) is not supported in variable blocks.
+  # The terraform-aws-vpc module will validate subnet/AZ alignment at apply time.
   validation {
-    # Ensure private subnet CIDRs align with the availability zone count.
-    condition     = length(var.private_subnet_cidrs) == length(var.azs)
-    error_message = "Number of private subnets must match number of availability zones."
+    condition     = length(var.private_subnet_cidrs) > 0
+    error_message = "At least one private subnet CIDR must be specified."
   }
 }
 
@@ -46,10 +48,12 @@ variable "public_subnet_cidrs" {
   description = "List of CIDR blocks for public subnets"
   type        = list(string)
 
+  # Note: Terraform variable validations can only reference the variable being validated (self).
+  # Cross-variable validation (e.g., subnet count == AZ count) is not supported in variable blocks.
+  # The terraform-aws-vpc module will validate subnet/AZ alignment at apply time.
   validation {
-    # Ensure public subnet CIDRs align with the availability zone count.
-    condition     = length(var.public_subnet_cidrs) == length(var.azs)
-    error_message = "Number of public subnets must match number of availability zones."
+    condition     = length(var.public_subnet_cidrs) > 0
+    error_message = "At least one public subnet CIDR must be specified."
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes EKS deployment failure caused by invalid cross-variable validations re-introduced in commit 437ac749.

## Problem
EKS deployment workflow failing with:
```
Error: Invalid reference in variable validation
The condition for variable "private_subnet_cidrs" can only refer to the variable itself
```

## Root Cause
Commit `437ac749` re-enabled cross-variable validations checking `length(var.private_subnet_cidrs) == length(var.azs)`, which violates Terraform's constraint that variable validations can ONLY reference themselves.

## Solution
- Removed cross-variable validation from `private_subnet_cidrs`
- Removed cross-variable validation from `public_subnet_cidrs`
- Changed to self-referencing validation: `length() > 0`
- Added comments explaining Terraform limitation
- VPC module validates subnet/AZ alignment at apply time

## Testing
- ✅ `terraform init -backend=false` passes
- ✅ `terraform validate` passes

## Related
- Fixes deployment failure from workflow run #19123217544
- Related to PR #113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Relaxed subnet CIDR validation requirements in networking configuration. Subnets now require only at least one CIDR specification instead of matching availability zone count, enabling more flexible network deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->